### PR TITLE
init(coder) must be failable

### DIFF
--- a/EGFloatingTextField/EGFloatingTextField/EGFloatingTextField.swift
+++ b/EGFloatingTextField/EGFloatingTextField/EGFloatingTextField.swift
@@ -46,7 +46,7 @@ public class EGFloatingTextField: UITextField {
     
     
     
-    required public init(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         self.commonInit()
     }


### PR DESCRIPTION
`init(coder)` is failable in the superclass, so it must be failable in this class
